### PR TITLE
Fix window closing issue with Vivaldi

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,5 @@
+chrome.action.onClicked.addListener(() => {
+    chrome.tabs.create({
+        url: chrome.runtime.getURL("page.html"),
+    });
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,8 +13,11 @@
     "offline_enabled": true,
 
     "action": {
-        "default_icon": "img/16.png",
-        "default_popup": "popup.html"
+        "default_icon": "img/16.png"
+    },
+    
+    "background": {
+        "service_worker": "background.js"
     },
 
     "permissions": ["management"]

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,1 +1,0 @@
-<script src="popup.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,5 +1,3 @@
 chrome.tabs.create({
     url: chrome.runtime.getURL('page.html')
 });
-
-window.close();

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,3 +1,0 @@
-chrome.tabs.create({
-    url: chrome.runtime.getURL('page.html')
-});


### PR DESCRIPTION
While using the Vivaldi browser, this extension causes all browser windows to close after clicking on the extension action.

There appears to be a bug in Vivaldi with calling `window.close()` in an extension popup. So instead of using the popup to initiate the page opening, I moved the code to a background script.

Vivaldi Forum thread on the issue: https://forum.vivaldi.net/topic/79248/export-links-of-all-extensions-crashes-the-browser